### PR TITLE
Move root package to com.example

### DIFF
--- a/src/main/java/com/example/PetApplication.java
+++ b/src/main/java/com/example/PetApplication.java
@@ -1,4 +1,4 @@
-package com.clianz;
+package com.example;
 
 import com.cloudant.client.api.CloudantClient;
 import com.cloudant.client.api.Database;

--- a/src/main/java/com/example/web/Pet.java
+++ b/src/main/java/com/example/web/Pet.java
@@ -1,4 +1,4 @@
-package com.clianz.web;
+package com.example.web;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/example/web/WebServer.java
+++ b/src/main/java/com/example/web/WebServer.java
@@ -1,4 +1,4 @@
-package com.clianz.web;
+package com.example.web;
 
 import java.util.concurrent.Callable;
 


### PR DESCRIPTION
I've tried your sample without success since `CloudantProperties` beans was defined 2 times instead of once. This is caused by `@SpringBootApplication`s `@ComponentScan` which creates an additional bean instance.

The fix was to simply rename the root package to `com.example`